### PR TITLE
Reduce assets when spending

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -26,6 +26,12 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSBonjourServices</key>
+	<array>
+		<string>_dartobservatory._tcp</string>
+	</array>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>ローカルネットワーク経由でデバッグサービスに接続するために使用します。</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>音声入力で家計簿を記録するためにマイクを使用します。</string>
 	<key>NSSpeechRecognitionUsageDescription</key>

--- a/lib/providers/asset_provider.dart
+++ b/lib/providers/asset_provider.dart
@@ -24,4 +24,15 @@ class AssetProvider extends ChangeNotifier {
     _assets[index] = _assets[index].copyWith(amount: newAmount);
     notifyListeners();
   }
+  
+  /// 指定アセットから支出分を減算する（下回る場合は0まで）
+  void decreaseAsset(String id, int amount) {
+    final index = _assets.indexWhere((asset) => asset.id == id);
+    if (index == -1) return;
+
+    final current = _assets[index].amount;
+    final next = current - amount;
+    _assets[index] = _assets[index].copyWith(amount: next < 0 ? 0 : next);
+    notifyListeners();
+  }
 }


### PR DESCRIPTION
- deduct asset balance when recording expenses via voice input, detecting asset by keywords (現金/銀行/ポイント; fallback cash)
- support simple Japanese units in amount parsing (万/千/百)
- add NSBonjourServices and NSLocalNetworkUsageDescription for iOS device run
